### PR TITLE
Show version number in application.

### DIFF
--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -33,6 +33,7 @@ module.exports = function (ctx) {
       // all: true, // --- includes everything; for dev only!
 
       components: [
+        'QBadge',
         'QBar',
         'QBtn',
         'QCircularProgress',

--- a/src-electron/main-process/electron-main.dev.js
+++ b/src-electron/main-process/electron-main.dev.js
@@ -8,11 +8,14 @@ import { app } from 'electron';
 import path from 'path';
 import electronDebug from 'electron-debug';
 import installExtension, { VUEJS_DEVTOOLS } from 'electron-devtools-installer';
-import { productName } from '../../package.json';
+import { productName, version } from '../../package.json';
 
 // Set user data path explicitly in DEV mode. Otherwise it would always be 'Electron'.
 const originalUserData = app.getPath('userData');
 app.setPath('userData', path.join(originalUserData, productName));
+
+// Set app version explicitly in DEV mode. Otherwise the app version of Electron would be shown.
+app.setVersion(version);
 
 // Show dev-tools
 electronDebug({ showDevTools: true, devToolsMode: 'undocked' });

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -18,6 +18,7 @@
       color="primary"
       label="Los gehts!"
     />
+    <q-badge class="index__versionfield fixed-bottom-right" color="primary" transparent>v{{appVersion}}</q-badge>
   </q-page>
 </template>
 
@@ -27,7 +28,8 @@ export default {
   data() {
     return {
       isVocabularyFileLoaded: false,
-      vocabularyFilePath: ''
+      vocabularyFilePath: '',
+      appVersion: ''
     };
   },
   beforeMount() {
@@ -42,6 +44,8 @@ export default {
     this.$q.electron.ipcRenderer.on('statisticsFileLoaded', (event, statistics) => {
       this.$store.commit('vocabulary/setStatistics', statistics);
     });
+
+    this.appVersion = this.$q.electron.remote.app.getVersion();
   },
   methods: {
     openVocabularyFile() {
@@ -58,5 +62,9 @@ export default {
 
 .index__vocabulary-missing__button {
   margin: 16px 0 0;
+}
+
+.index__versionfield {
+  margin: 16px;
 }
 </style>


### PR DESCRIPTION
- Shown in bottom right corner of Index page.
- In DEV mode explicitly set, because otherwise it would always show version of Electron.